### PR TITLE
Fixed CMake errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
 cmake_minimum_required (VERSION 2.8)
 
+set(CMAKE_VERBOSE_MAKEFILE on)
+
 add_subdirectory (src) 

--- a/src/tdigest/CMakeLists.txt
+++ b/src/tdigest/CMakeLists.txt
@@ -4,9 +4,9 @@ add_library (tdigest
     tdigest.cpp
 )
 
-list(APPEND CMAKE_CXX_FLAGS "-std=c++11 -O0 -g -fprofile-arcs -ftest-coverage -DNDEBUG ${CMAKE_CXX_FLAGS}")
-list(APPEND CMAKE_C_FLAGS " -O0 -g -fprofile-arcs -ftest-coverage -DNDEBUG ${CMAKE_C_FLAGS}")
-list(APPEND CMAKE_EXE_LINKER_FLAGS "-O0 -g -fprofile-arcs -ftest-coverage -DNDEBUG ${CMAKE_EXE_LINKER_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O0 -g -fprofile-arcs -ftest-coverage -DNDEBUG")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -g -fprofile-arcs -ftest-coverage -DNDEBUG")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -O0 -g -fprofile-arcs -ftest-coverage -DNDEBUG")
 
 add_executable (demo main.cpp)
 target_link_libraries (demo tdigest)

--- a/src/tdigest/avltree.cpp
+++ b/src/tdigest/avltree.cpp
@@ -254,3 +254,71 @@ void AvlTree::rotateRight(int node) {
     updateAggregates(node);
     updateAggregates(parentNode(node));
 }
+
+
+struct SerializedTreeNode
+{
+  int parent;
+  int left;
+  int right;
+  char depth;
+  int count;
+  double values;
+  int aggregatedCount;
+};
+
+struct SerializedTree
+{
+  int root;
+  int n;
+  SerializedTreeNode nodes[0];
+};
+
+void AvlTree::save(std::string& out) {
+
+  size_t len = (sizeof(SerializedTree) + 
+      ((_n + 1) * sizeof(SerializedTreeNode)));
+  char* buf = (char*)malloc(len);
+ 
+  SerializedTree* header = (SerializedTree*)buf;
+  header->n = _n;
+  header->root = _root;
+
+  for (int idx = 0; idx <= _n; idx ++)
+  {
+    header->nodes[idx].parent = _parent[idx];
+    header->nodes[idx].left = _left[idx];
+    header->nodes[idx].right = _right[idx];
+    header->nodes[idx].depth = _depth[idx];
+    header->nodes[idx].count = _count[idx];
+    header->nodes[idx].values = _values[idx];
+    header->nodes[idx].aggregatedCount = _aggregatedCount[idx];
+  }
+
+  out.append(buf, len);
+  free(buf);
+}
+
+void AvlTree::load(const std::string& in) {
+  SerializedTree* header = (SerializedTree*)in.data();
+
+  assert(header->n > 0);
+  assert(header->n < MAXNODE);
+
+  _root = header->root;
+  _n = header->n;
+
+  SerializedTreeNode* nodes = (SerializedTreeNode*)
+    (in.data() + sizeof(SerializedTree));
+ 
+  for (int idx = 0; idx <= _n; idx ++)
+  {
+    _parent[idx] = nodes[idx].parent;
+    _left[idx] = nodes[idx].left;
+    _right[idx] = nodes[idx].right;
+    _depth[idx] = nodes[idx].depth;
+    _count[idx] = nodes[idx].count;
+    _values[idx] = nodes[idx].values;
+    _aggregatedCount[idx] = nodes[idx].aggregatedCount;
+  }
+}

--- a/src/tdigest/avltree.hpp
+++ b/src/tdigest/avltree.hpp
@@ -254,5 +254,8 @@ class AvlTree {
             print(_root);
         }
 
+        void save(std::string& out);
+
+        void load(const std::string& in);
 };
 

--- a/src/tdigest/avltree.hpp
+++ b/src/tdigest/avltree.hpp
@@ -1,5 +1,4 @@
-#ifndef HEADER_AVLTREE
-#define HEADER_AVLTREE
+#pragma once
 
 #include <cassert>
 #include <cmath>
@@ -12,21 +11,24 @@ using namespace std;
 class AvlTree {
 
     private:
+
+      static constexpr size_t MAXNODE = 1000;
+
         int       _root;
         int       _n = 0;
         // TODO We should reallocate tables (ie allow dynamic arrays)
-        int       _parent[1000];
-        int       _left[1000];
-        int       _right[1000];
-        char      _depth[1000];
-        int       _count[1000];
-        double    _values[1000];
-        int       _aggregatedCount[1000];
+        int       _parent[MAXNODE];
+        int       _left[MAXNODE];
+        int       _right[MAXNODE];
+        char      _depth[MAXNODE];
+        int       _count[MAXNODE];
+        double    _values[MAXNODE];
+        int       _aggregatedCount[MAXNODE];
 
     public:
         static const int NIL = 0;
 
-        AvlTree();
+        explicit AvlTree();
 
         //
         // Node comparison
@@ -254,4 +256,3 @@ class AvlTree {
 
 };
 
-#endif

--- a/src/tdigest/tdigest.cpp
+++ b/src/tdigest/tdigest.cpp
@@ -60,3 +60,29 @@ double TDigest::quantile(double q) {
 
 }
 
+struct SerializedDigest
+{
+  double    compression;
+  double    count;
+};
+
+void TDigest::save(std::string& out)
+{
+  SerializedDigest d;
+  d.compression = _compression;
+  d.count = _count;
+
+  out.append((char*)&d, sizeof(d));
+
+  _centroids->save(out);
+}
+
+void TDigest::load(const std::string& in)
+{
+  SerializedDigest* d = (SerializedDigest*)in.data();
+  _compression = d->compression;
+  _count = d->count;
+
+  _centroids->load(in.substr(sizeof(*d), in.size() - sizeof(*d)));
+}
+

--- a/src/tdigest/tdigest.hpp
+++ b/src/tdigest/tdigest.hpp
@@ -1,7 +1,7 @@
-#ifndef HEADER_TDIGEST
-#define HEADER_TDIGEST
+#pragma once
 
 #include <cfloat>
+#include <memory>
 
 #include "avltree.hpp"
 
@@ -14,12 +14,14 @@ class TDigest {
     private:
         double    _compression     = 100;
         double    _count           = 0;
-        AvlTree*  _centroids       = new AvlTree();
+        std::unique_ptr<AvlTree>  _centroids;
 
     public:
-        TDigest (double compression): _compression(compression) {}
-
-        ~TDigest() { delete _centroids ;}
+        TDigest (double compression)
+          : _compression(compression) 
+        {
+          _centroids = std::unique_ptr<AvlTree>(new AvlTree());
+        }
 
         inline long size() const {
             return _count;
@@ -106,7 +108,7 @@ class TDigest {
         }
 
         inline AvlTree* centroids() const {
-            return _centroids;
+            return _centroids.get();
         }
 
         inline void merge(TDigest* digest) {
@@ -121,4 +123,3 @@ class TDigest {
 
 };
 
-#endif

--- a/src/tdigest/tdigest.hpp
+++ b/src/tdigest/tdigest.hpp
@@ -121,5 +121,14 @@ class TDigest {
         void compress();
         double quantile(double q);
 
+        void save(std::string& out) {
+          // TODO also save compression and count
+          _centroids->save(out);
+        }
+
+        void load(const std::string& in) {
+          _centroids->load(in);
+        }
+
 };
 

--- a/src/tdigest/tdigest.hpp
+++ b/src/tdigest/tdigest.hpp
@@ -121,14 +121,8 @@ class TDigest {
         void compress();
         double quantile(double q);
 
-        void save(std::string& out) {
-          // TODO also save compression and count
-          _centroids->save(out);
-        }
+        void save(std::string& out);
 
-        void load(const std::string& in) {
-          _centroids->load(in);
-        }
-
+        void load(const std::string& in);
 };
 

--- a/src/tdigest/tdigest.hpp
+++ b/src/tdigest/tdigest.hpp
@@ -19,6 +19,8 @@ class TDigest {
     public:
         TDigest (double compression): _compression(compression) {}
 
+        ~TDigest() { delete _centroids ;}
+
         inline long size() const {
             return _count;
         }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -16,4 +16,14 @@ target_link_libraries (AvlTreeTest
     pthread
 )
 
-add_test(TestAvlTree AvlTreeTest)
+add_executable (TDigestTest tdigest_test.cpp)
+
+target_link_libraries (TDigestTest
+    tdigest
+    ${GTEST_BOTH_LIBRARIES}
+    pthread
+)
+
+add_test(TestAvlTree 
+  AvlTreeTest
+  TDigestTest)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,9 +1,9 @@
 project(cpptdigest-tests)
 
 enable_testing()
-list(APPEND CMAKE_CXX_FLAGS "-std=c++11 -O0 -g -fprofile-arcs -ftest-coverage -DNDEBUG ${CMAKE_CXX_FLAGS}")
-list(APPEND CMAKE_C_FLAGS " -O0 -g -fprofile-arcs -ftest-coverage -DNDEBUG ${CMAKE_C_FLAGS}")
-list(APPEND CMAKE_EXE_LINKER_FLAGS "-O0 -g -fprofile-arcs -ftest-coverage -DNDEBUG ${CMAKE_EXE_LINKER_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O0 -g -fprofile-arcs -ftest-coverage -DNDEBUG")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -g -fprofile-arcs -ftest-coverage -DNDEBUG ")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -O0 -g -fprofile-arcs -ftest-coverage -DNDEBUG")
 
 find_package(GTest REQUIRED)
 include_directories(${GTEST_INCLUDE_DIRS})
@@ -13,6 +13,7 @@ add_executable (AvlTreeTest avltree.cpp)
 target_link_libraries (AvlTreeTest
     tdigest
     ${GTEST_BOTH_LIBRARIES}
+    pthread
 )
 
 add_test(TestAvlTree AvlTreeTest)

--- a/src/tests/avltree.cpp
+++ b/src/tests/avltree.cpp
@@ -22,3 +22,34 @@ TEST(AvlTreeTest, GenericTest) {
     ASSERT_EQ(tree->checkAggregates(), true);
     ASSERT_EQ(tree->checkIntegrity(), true);
 }
+
+TEST(AvlTreeTest, LoadSave) {
+    AvlTree* tree = new AvlTree();
+
+    ASSERT_EQ(tree->root(), 0);
+    ASSERT_EQ(tree->size(), 0);
+
+    tree->add(5., 3);
+    tree->add(8., 1);
+    tree->add(9., 2);
+    tree->add(4., 2);
+    tree->add(7., 2);
+    tree->add(6., 2);
+    tree->add(2., 2);
+    tree->add(1., 6);
+    tree->add(3., 6);
+
+    std::string out_string;
+    tree->save(out_string);
+
+    AvlTree* newtree = new AvlTree();
+    newtree->load(out_string);
+
+    EXPECT_EQ(tree->root(), newtree->root());
+    EXPECT_EQ(tree->size(), newtree->size());
+
+    ASSERT_EQ(newtree->checkBalance(), true);
+    ASSERT_EQ(newtree->checkAggregates(), true);
+    ASSERT_EQ(newtree->checkIntegrity(), true);
+
+}

--- a/src/tests/tdigest_test.cpp
+++ b/src/tests/tdigest_test.cpp
@@ -1,0 +1,21 @@
+#include "../tdigest/tdigest.hpp"
+
+#include <gtest/gtest.h>
+
+TEST(TDigestTest, LoadSave) {
+    TDigest* tdigest = new TDigest(100);
+
+    for (int i = 0; i < 1000; i++) 
+    {
+      tdigest->add(rand() % 1001);
+    }
+
+    std::string str;
+    tdigest->save(str);
+
+    TDigest* new_digest = new TDigest(100);
+    new_digest->load(str);
+
+    EXPECT_EQ(new_digest->quantile(0.5), tdigest->quantile(0.5));
+}
+


### PR DESCRIPTION
Added pthread dependency

Set compiler flags using set() instead of list(APPEND, ) to prevent
the problem discussed here
http://stackoverflow.com/questions/16433391/cmake-list-append-for-compiler-flags-yields-bogus-results
