### PR TITLE
do not use namespace std

### DIFF
--- a/src/tdigest/avltree.hpp
+++ b/src/tdigest/avltree.hpp
@@ -5,10 +5,6 @@
 #include <cmath>
 #include <iostream>
 
-
-using namespace std;
-
-
 class AvlTree {
 
     private:
@@ -122,7 +118,7 @@ class AvlTree {
         // O(1)
         inline void updateAggregates(int node) {
             // Updating depth
-            _depth[node] = 1 + max(depth(leftNode(node)), depth(rightNode(node)));
+            _depth[node] = 1 + std::max(depth(leftNode(node)), depth(rightNode(node)));
             _aggregatedCount[node] = count(node) + aggregatedCount(leftNode(node)) + aggregatedCount(rightNode(node));
         }
 
@@ -187,7 +183,7 @@ class AvlTree {
             if(node == NIL) {
                 return depth(node) == 0;
             } else {
-                return depth(node) == 1 + max(depth(leftNode(node)), depth(rightNode(node)))
+                return depth(node) == 1 + std::max(depth(leftNode(node)), depth(rightNode(node)))
                     && abs(depth(leftNode(node)) - depth(rightNode(node))) <= 1
                     && checkBalance(leftNode(node))
                     && checkBalance(rightNode(node))
@@ -238,13 +234,13 @@ class AvlTree {
         void print(int node) const {
             if(node == NIL)
                 return;
-            cout << "Node " << node << "=> ";
-            cout << "Value:" << _values[node] << " ";
-            cout << "(" << _values[leftNode(node)] << ";";
-            cout << "" << _values[rightNode(node)] << ") ";
-            cout << "Depth: " << depth(node) << " ";
-            cout << "Count: " <<_count[node] << " ";
-            cout << "Aggregate: " << _aggregatedCount[node] << endl;
+            std::cout << "Node " << node << "=> ";
+            std::cout << "Value:" << _values[node] << " ";
+            std::cout << "(" << _values[leftNode(node)] << ";";
+            std::cout << "" << _values[rightNode(node)] << ") ";
+            std::cout << "Depth: " << depth(node) << " ";
+            std::cout << "Count: " <<_count[node] << " ";
+            std::cout << "Aggregate: " << _aggregatedCount[node] << std::endl;
             print(leftNode(node));
             print(rightNode(node));
         }

--- a/src/tdigest/tdigest.hpp
+++ b/src/tdigest/tdigest.hpp
@@ -2,12 +2,7 @@
 #define HEADER_TDIGEST
 
 #include <cfloat>
-
 #include "avltree.hpp"
-
-
-using namespace std;
-
 
 class TDigest {
 
@@ -82,7 +77,7 @@ class TDigest {
                 _count += w;
 
                 if(_centroids->size() > 20 * _compression) {
-                    cout << "Compress:" << _centroids->size() << endl;
+                    std::cout << "Compress:" << _centroids->size() << std::endl;
                     compress();
                 }
             }


### PR DESCRIPTION
Doing so may prevent seamless integration between this and other
projects. This happens because one may have a class, in a namespace,
that shares the same name as one of the std classes. When including
the tdigest hpp files, that would create conflicts involving those
classes.

"using namespace xxx" should be fine in .cpp files.